### PR TITLE
Expanding the CI workflows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^codecov\.yml$

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,54 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    continue-on-error: ${{ matrix.config.must_pass }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+            # Windows
+          - {os: windows-latest, r: 'release', must_pass: true}
+            # Use 3.6 to trigger usage of RTools35
+          - {os: windows-latest, r: '3.6', must_pass: true}
+            # Linux
+          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', must_pass: false}
+          - {os: ubuntu-latest, r: 'release', must_pass: true}
+          - {os: ubuntu-latest, r: 'oldrel-1', must_pass: true}
+          - {os: ubuntu-latest, r: 'oldrel-2', must_pass: true}
+          - {os: ubuntu-latest, r: '3.6.1', must_pass: true}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,30 +11,34 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-    continue-on-error: ${{ matrix.config.must_pass }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
             # Windows
-          - {os: windows-latest, r: 'release', must_pass: true}
+          - {os: windows-latest, r: 'release'}
             # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6', must_pass: true}
+          - {os: windows-latest, r: '3.6'}
             # Linux
-          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', must_pass: false}
-          - {os: ubuntu-latest, r: 'release', must_pass: true}
-          - {os: ubuntu-latest, r: 'oldrel-1', must_pass: true}
-          - {os: ubuntu-latest, r: 'oldrel-2', must_pass: true}
-          - {os: ubuntu-latest, r: '3.6.1', must_pass: true}
+          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest, r: 'release'}
+            # Mac OS
+          - {os: macos-latest,   r: 'release'}
+
+            # Vesions in use on PHS PWB
+          - {os: ubuntu-latest, r: '4.0.2'}
+          - {os: ubuntu-latest, r: '4.1.2'}
+          - {os: ubuntu-latest, r: '3.6.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,44 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["R/**"]
+  pull_request:
+    paths: ["R/**"]
+
+name: Document
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: roxygen2
+
+      - name: Document
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add man/\* NAMESPACE
+          git commit -m "Update documentation" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -3,8 +3,6 @@
 on:
   push:
     paths: ["R/**"]
-  pull_request:
-    paths: ["R/**"]
 
 name: Document
 
@@ -35,6 +33,10 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Update documentation"
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add man/\* NAMESPACE DESCRIPTION
+          git commit -m "Update documentation" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -35,10 +35,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
-          git commit -m "Update documentation" || echo "No changes to commit"
-          git pull --ff-only
-          git push origin
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Update documentation"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,30 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,6 +3,8 @@
 on:
   push:
     branches: [main, master]
+  pull_request:
+    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
@@ -12,10 +14,15 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -34,7 +41,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -17,19 +17,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Deploy package
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,68 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
+  pull_request:
+    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
+
+name: Style
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::styler
+          needs: styler
+
+      - name: Enable styler cache
+        run: styler::cache_activate()
+        shell: Rscript {0}
+
+      - name: Determine cache location
+        id: styler-location
+        run: |
+          cat(
+            "##[set-output name=location;]",
+            styler::cache_info(format = "tabular")$location,
+            "\n",
+            sep = ""
+          )
+        shell: Rscript {0}
+
+      - name: Cache styler
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.styler-location.outputs.location }}
+          key: ${{ runner.os }}-styler-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-styler-
+            ${{ runner.os }}-
+
+      - name: Style
+        run: styler::style_pkg(filetype = c(".R", ".Rmd", ".Rmarkdown", ".Rnw"))
+        shell: Rscript {0}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add R/\*
+          git commit -m "Style code" || echo "No changes to commit"
+          git pull --ff-only
+          git push origin

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,9 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw"]
-  pull_request:
-    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw"]
+    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw", "**.[rR]profile"]
 
 name: Style
 
@@ -27,7 +25,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::styler, any::roxygen2, any::knitr
+          extra-packages: any::styler, any::roxygen2
           needs: styler
 
       - name: Enable styler cache
@@ -57,10 +55,19 @@ jobs:
             ${{ runner.os }}-
 
       - name: Style
-        run: styler::style_pkg(filetype = c(".R", ".Rmd", ".Rmarkdown", ".Rnw"))
+        run: styler::style_pkg()
         shell: Rscript {0}
 
-      - name: Commit and push changes on all other branches
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Style code"
+      - name: Commit and push changes
+        run: |
+          if FILES_TO_COMMIT=($(git diff-index --name-only ${{ github.sha }} \
+              | egrep --ignore-case '\.(R|[qR]md|Rmarkdown|Rnw|Rprofile)$'))
+          then
+            git config --local user.name "$GITHUB_ACTOR"
+            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git commit ${FILES_TO_COMMIT[*]} -m "Style code (GHA)"
+            git pull --ff-only
+            git push origin
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
+    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw"]
   pull_request:
-    paths: ["**.[rR]", "**.[rR]md", "**.[rR]markdown", "**.[rR]nw"]
+    paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw"]
 
 name: Style
 
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -38,15 +38,17 @@ jobs:
         id: styler-location
         run: |
           cat(
-            "##[set-output name=location;]",
+            "location=",
             styler::cache_info(format = "tabular")$location,
             "\n",
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE,
             sep = ""
           )
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}
@@ -58,11 +60,7 @@ jobs:
         run: styler::style_pkg(filetype = c(".R", ".Rmd", ".Rmarkdown", ".Rnw"))
         shell: Rscript {0}
 
-      - name: Commit and push changes
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add R/\*
-          git commit -m "Style code" || echo "No changes to commit"
-          git pull --ff-only
-          git push origin
+      - name: Commit and push changes on all other branches
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Style code"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::styler
+          extra-packages: any::styler, any::roxygen2, any::knitr
           needs: styler
 
       - name: Enable styler cache

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,31 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+          needs: coverage
+
+      - name: Test coverage
+        run: covr::codecov(quiet = FALSE)
+        shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -27,5 +27,24 @@ jobs:
           needs: coverage
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     ggplot2, 
     scales
 Suggests: 
+    covr,
     testthat (>= 3.0.0)
 Encoding: UTF-8
 LazyData: true

--- a/R/data.R
+++ b/R/data.R
@@ -34,7 +34,7 @@
 #' | x | supporting-liberties |
 #' | x | supporting-rusts |
 #'
-#'@md
+#' @md
 #'
 #' @format A character list
 "phs_palettes"
@@ -64,7 +64,7 @@
 #' | x | supporting-liberties |
 #' | x | supporting-rusts |
 #'
-#'@md
+#' @md
 #'
 #' @format A character list
 "phs_palette_types"

--- a/R/phs_pal.R
+++ b/R/phs_pal.R
@@ -8,10 +8,9 @@ phs_pal <- function(type = "seq", palette = 1, direction = 1,
     if (direction == -1) {
       pal <- rev(pal)
     }
-    if(colour_names == TRUE){
+    if (colour_names == TRUE) {
       pal
-    }
-    else{
+    } else {
       as.vector(pal)
     }
   }

--- a/R/phs_pal1.R
+++ b/R/phs_pal1.R
@@ -3,13 +3,17 @@ phs_pal1 <- function(n, name) {
   phs_palettes <- phsstyles::phs_palettes
 
   if (!(name %in% names(phs_palettes))) {
-    stop(paste(name,"is not a valid palette name.\n"))
+    stop(paste(name, "is not a valid palette name.\n"))
   }
 
   if (n > length(phs_palettes[[name]]) & !(name %in% phs_palette_types[["seq"]])) {
-    warning(paste("n too large, allowed maximum for palette", name, "is",
-                  length(phs_palettes[[name]])),
-            "\nReturning the palette you asked for with that many colors\n")
+    warning(
+      paste(
+        "n too large, allowed maximum for palette", name, "is",
+        length(phs_palettes[[name]])
+      ),
+      "\nReturning the palette you asked for with that many colors\n"
+    )
     return(phs_pal1(length(phs_palettes[[name]]), name))
   }
 

--- a/R/phsstyles.R
+++ b/R/phsstyles.R
@@ -11,6 +11,10 @@ NULL
 
 # Stops notes from appearing in R CMD check because of undefined global
 # variables
-if (getRversion() >= "2.15.1") utils::globalVariables(c("phs_colour_values",
-                                                        "phs_palette_types",
-                                                        "phs_palettes"))
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(c(
+    "phs_colour_values",
+    "phs_palette_types",
+    "phs_palettes"
+  ))
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/Public-Health-Scotland/phsstyles)](https://github.com/Public-Health-Scotland/phsstyles/releases/latest)
 
+[![Codecov test coverage](https://codecov.io/gh/Public-Health-Scotland/phsstyles/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Public-Health-Scotland/phsstyles?branch=master)
 
 [![R-CMD-check](https://github.com/Public-Health-Scotland/phsstyles/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Public-Health-Scotland/phsstyles/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
@@ -110,7 +111,7 @@ library(ggplot2)
 # Apply PHS theme to a chart
 qplot(mpg, wt, data = mtcars) + theme_phs()
 
-# Overwirte a feature (e.g. remove vertical gridlines and add horizontal ones)
+# Overwrite a feature (e.g. remove vertical gridlines and add horizontal ones)
 qplot(mpg, wt, data = mtcars) + theme_phs() +
   theme(panel.grid.major.x = element_blank(), 
         panel.grid.major.y = element_line(colour = 

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,12 @@ knitr::opts_chunk$set(
 
 # phsstyles
 
+<!-- badges: start -->
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/Public-Health-Scotland/phsstyles)](https://github.com/Public-Health-Scotland/phsstyles/releases/latest)
+
+
+[![R-CMD-check](https://github.com/Public-Health-Scotland/phsstyles/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Public-Health-Scotland/phsstyles/actions/workflows/R-CMD-check.yaml)
+<!-- badges: end -->
 
 There are 8 colours for use in [Public Health Scotland (PHS)](https://www.publichealthscotland.scot/):
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
I'm updating the CI on all the PHS packages.

I updated the pkgdown workflow to be based off of the r-lib actions v2 example.

I've added a workflow and infrastructure to work out and report test coverage to codecov.io

I've added an R-CMD check to use the standard actions from r-lib. It tests against quite a few R versions with an argument to specify whether they are `must_pass` or not i.e. will the whole workflow fail if they do? The versions of R selected are from a brief chat with Russell and are trying to balance what is available now with what we will have on the new R infrastructure, as well as what any external users might be using...

I've also added workflows to automatically document, style and lint any code. The idea is that these will run on any PR code and resolve any simple issues automatically.