### PR TITLE
Tidy the docs for the colour  / color functions

### DIFF
--- a/R/scale_colour_continuous_phs.R
+++ b/R/scale_colour_continuous_phs.R
@@ -66,8 +66,6 @@ scale_colour_continuous_phs <- function(..., type = "seq", palette = 1,
 }
 
 #' @rdname scale_colour_continuous_phs
-#' @examples
-#' ggplot2::qplot(mpg, wt, data = mtcars, colour = cyl) +
-#' scale_color_continuous_phs(palette = "main-purples")
+#' @usage NULL
 #' @export
 scale_color_continuous_phs <- scale_colour_continuous_phs

--- a/R/scale_colour_discrete_phs.R
+++ b/R/scale_colour_discrete_phs.R
@@ -31,10 +31,6 @@ scale_colour_discrete_phs <- function(..., type = "seq", palette = 1,
 }
 
 #' @rdname scale_colour_discrete_phs
-#' @examples
-#' df <- mtcars
-#' df[,'cyl'] <- as.factor(df[,'cyl'])
-#' ggplot2::qplot(mpg, wt, data = df, colour = cyl) +
-#' scale_color_discrete_phs(palette = "main")
+#' @usage NULL
 #' @export
 scale_color_discrete_phs <- scale_colour_discrete_phs


### PR DESCRIPTION
At the moment they both appear in the docs - This brings it in line with how `ggplot2` documents the `colour` vs `color` functions and basically has one help/doc page for `colour` where `color` just redirects to.